### PR TITLE
fix: Improve UI responsiveness using a queue

### DIFF
--- a/sniffer.py
+++ b/sniffer.py
@@ -3,12 +3,14 @@ import tkinter as tk
 from tkinter import scrolledtext
 from nettypes import EthernetFrame
 import threading
+import queue # Import the queue module
 
 # Global event to signal the sniffing thread to stop
 stop_sniffing_event = threading.Event()
 sniffer_thread = None # To keep track of the sniffing thread
+packet_queue = queue.Queue() # Global queue for packet data
 
-# Function to update the text area from any thread
+# Function to update the text area from any thread (for status messages)
 def update_text_area(message):
     text_area.config(state='normal')
     text_area.insert(tk.END, message)
@@ -16,32 +18,35 @@ def update_text_area(message):
     text_area.config(state='disabled')
 
 # Modified main function for packet sniffing
-def packet_sniffer_worker(ui_text_area, stop_event):
+def packet_sniffer_worker(ui_text_area, stop_event, data_queue): # Added data_queue parameter
     conn = None
     error_occurred_in_worker = False
     try:
         # This requires root privileges
         conn = socket.socket(socket.AF_PACKET, socket.SOCK_RAW, socket.ntohs(3))
+        # Status update remains direct UI update
         root.after_idle(update_text_area, "Sniffing started...\n")
         while not stop_event.is_set():
             try:
                 raw_data, addr = conn.recvfrom(65536) # Increased buffer size slightly
                 ethernet_frame = EthernetFrame(raw_data)
                 frame_info = str(ethernet_frame)
-                # Schedule UI update on the main thread
-                root.after_idle(update_text_area, frame_info + "\n\n")
+                # Put packet data string into the queue
+                data_queue.put(frame_info + "\n\n")
             except Exception as loop_e: # Catch errors within the loop
                 error_msg = f"Error during packet processing: {loop_e}\n"
-                root.after_idle(update_text_area, error_msg)
-                # Optionally, decide if the loop should continue or break on certain errors
+                # Put error message related to packet processing into the queue
+                data_queue.put(error_msg)
                 # For now, it continues trying to read next packet.
     except PermissionError:
         error_msg = "Permission Denied: Root privileges are required to create raw sockets.\nPlease run the script as root (e.g., using sudo).\n"
+        # Critical error, update UI directly
         root.after_idle(update_text_area, error_msg)
         error_occurred_in_worker = True
     except Exception as e:
         # Catch other potential errors during sniffing setup or critical failures
         error_msg = f"An unexpected error occurred: {e}\n"
+        # Critical error, update UI directly
         root.after_idle(update_text_area, error_msg)
         error_occurred_in_worker = True
     finally:
@@ -54,7 +59,8 @@ def packet_sniffer_worker(ui_text_area, stop_event):
         elif not stop_event.is_set():
              # If loop exited without stop_event being set and no error, it's unexpected.
              stop_message = "Sniffing stopped unexpectedly.\n"
-
+        
+        # Final status update remains direct UI update
         root.after_idle(update_text_area, stop_message)
         # Ensure buttons are reset correctly even if sniffing stops due to error
         root.after_idle(reset_button_states_after_stop)
@@ -62,29 +68,60 @@ def packet_sniffer_worker(ui_text_area, stop_event):
 def start_sniffing():
     global sniffer_thread
     if sniffer_thread and sniffer_thread.is_alive():
-        # Prevent starting multiple threads if one is already running (shouldn't happen with button states)
         return
 
     stop_sniffing_event.clear()
     start_button.config(state='disabled')
     stop_button.config(state='normal')
     
-    # Clear previous content in text_area before starting new sniffing
     text_area.config(state='normal')
     text_area.delete('1.0', tk.END)
     text_area.config(state='disabled')
 
-    sniffer_thread = threading.Thread(target=packet_sniffer_worker, args=(text_area, stop_sniffing_event))
-    sniffer_thread.daemon = True # Allows main program to exit even if thread is running
+    # Pass the global packet_queue to the worker thread
+    sniffer_thread = threading.Thread(target=packet_sniffer_worker, args=(text_area, stop_sniffing_event, packet_queue))
+    sniffer_thread.daemon = True 
     sniffer_thread.start()
+    # Start the queue processing loop
+    process_packet_queue()
 
 def stop_sniffing():
     stop_sniffing_event.set()
-    # Button states will be updated by the worker thread's finally block or reset_button_states_after_stop
+    
+    # Clear any remaining items from the packet_queue
+    # This prevents old packets from appearing if sniffing is restarted
+    while not packet_queue.empty():
+        try:
+            packet_queue.get_nowait()
+        except queue.Empty:
+            # This should ideally not be reached if .empty() is reliable,
+            # but good for robustness.
+            break
+        except Exception: 
+            # Catch any other unexpected error during queue clearing
+            # Optionally log this, but for now, just break to avoid an infinite loop.
+            break
+    
+    # Button states will be updated by the worker thread's finally block 
+    # or reset_button_states_after_stop which is called from the worker's finally.
+    # The process_packet_queue will also stop rescheduling itself because stop_sniffing_event is set.
 
 def reset_button_states_after_stop():
     start_button.config(state='normal')
     stop_button.config(state='disabled')
+
+# Function to process messages from the packet_queue and update UI
+def process_packet_queue():
+    try:
+        while True: # Process all messages currently in the queue
+            message = packet_queue.get_nowait()
+            update_text_area(message) # update_text_area handles enabling/disabling text_area
+    except queue.Empty:
+        pass # Queue is empty, no more messages for now
+
+    # If sniffing is still active, schedule this function to run again
+    if not stop_sniffing_event.is_set():
+        root.after(100, process_packet_queue) # Check queue every 100ms
 
 # Create the main window
 root = tk.Tk()


### PR DESCRIPTION
This commit addresses UI choppiness and delayed packet display during live packet capture.

The key changes include:
- Implemented a `queue.Queue` for communication between the sniffing thread and the main UI thread.
- The sniffing thread now puts captured packet data (formatted strings and in-loop error messages) onto this queue.
- A new function, `process_packet_queue`, runs in the main UI thread and periodically polls the queue (every 100ms) to retrieve and display new packet data.
- This decouples the packet capture rate from the UI update rate, preventing the UI from becoming overwhelmed and ensuring smoother, more real-time display of packets.
- The packet queue is now also cleared when sniffing is stopped to prevent stale data from appearing on subsequent captures.